### PR TITLE
Bump minimum required sol version

### DIFF
--- a/contracts/ERC1155.sol
+++ b/contracts/ERC1155.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 /// @notice Modern and gas-optimized ERC-1155 implementation.
 /// @author Modified from Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC1155.sol)

--- a/contracts/Helios.sol
+++ b/contracts/Helios.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 import './ERC1155.sol';
 import './libraries/SafeTransferLib.sol';

--- a/contracts/ISwap.sol
+++ b/contracts/ISwap.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 interface ISwap {
     function addLiquidity(uint256 token0amount, uint256 token1amount) external returns (uint256 lp);

--- a/contracts/libraries/SafeTransferLib.sol
+++ b/contracts/libraries/SafeTransferLib.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 /// @notice Safe ETH and ERC-20 transfer library that gracefully handles missing return values.
 /// @author Modified from SolMate (https://github.com/Rari-Capital/solmate/blob/main/src/utils/SafeTransferLib.sol)

--- a/contracts/libraries/math/SqrtMath.sol
+++ b/contracts/libraries/math/SqrtMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 /// @notice Babylonian method for computing square roots.
 /// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/utils/FixedPointMathLib.sol)

--- a/contracts/utils/Multicall.sol
+++ b/contracts/utils/Multicall.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity >=0.8.0;
+pragma solidity >=0.8.4;
 
 /// @notice Helper utility that enables calling multiple local methods in a single call.
 /// @author Modified from Uniswap (https://github.com/Uniswap/v3-periphery/blob/main/contracts/base/Multicall.sol)


### PR DESCRIPTION
Needs to be >=0.8.4 due to the use of custom errors.

https://blog.soliditylang.org/2021/04/21/custom-errors/